### PR TITLE
[정필모] 2024-07-08 풀이 제출

### DIFF
--- a/week6/leetcode/1823-find-the-winner-of-the-circular-game/itsmo1031.java
+++ b/week6/leetcode/1823-find-the-winner-of-the-circular-game/itsmo1031.java
@@ -1,0 +1,22 @@
+class Solution {
+	public int findTheWinner(int n, int k) {
+		Deque<Integer> game = new ArrayDeque<>();
+
+		for (int i = 1; i <= n; i++) {
+			game.offerLast(i);
+		}
+
+		int left = k;
+		while (game.size() > 1) {
+			left -= 1;
+			int current = game.pollFirst();
+			if (left == 0) {
+				left = k;
+				continue;
+			}
+			game.offerLast(current);
+		}
+
+		return game.pollFirst();
+	}
+}

--- a/week6/programmers/72414-광고-삽입/itsmo1031.java
+++ b/week6/programmers/72414-광고-삽입/itsmo1031.java
@@ -1,0 +1,55 @@
+class Solution {
+	static long[] timeline;
+
+	public String solution(String play_time, String adv_time, String[] logs) {
+		// 최대 99시간 59분 59초
+		timeline = new long[100 * 3600];
+
+		int playTime = toSec(play_time);
+		int advTime = toSec(adv_time);
+
+		for (String log : logs) {
+			String[] info = log.split("-");
+
+			int start = toSec(info[0]);
+			int end = toSec(info[1]);
+
+			for (int i = start; i < end; i++) {
+				timeline[i] += 1;
+			}
+		}
+
+		long acc = 0;
+		for (int i = 0; i < advTime; i++) {
+			acc += timeline[i];
+		}
+		long max = acc;
+		int res = 0;
+
+		for (int i = advTime; i < playTime; i++) {
+			acc = acc - timeline[i - advTime] + timeline[i];
+			if (acc > max) {
+				max = acc;
+				res = i - advTime + 1;
+			}
+		}
+
+		return formatTime(res);
+	}
+
+	static int toSec(String time) {
+		String[] times = time.split(":");
+		return Integer.parseInt(times[0]) * 3600 +
+				Integer.parseInt(times[1]) * 60 +
+				Integer.parseInt(times[2]);
+	}
+
+	static String formatTime(int sec) {
+		int hour = sec / 3600;
+		sec %= 3600;
+		int min = sec / 60;
+		sec %= 60;
+
+		return String.format("%02d:%02d:%02d", hour, min, sec);
+	}
+}


### PR DESCRIPTION
# 2024-07-08

## Leetcode

### 1823. Find the Winner of the Circular Game

> Runtime: 36ms
> Memory: 44.33MB

#### 🚩 문제 난이도

- [ ] ✅ 막힘 없이 풀었어요.
- [X] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

Deque를 선언해서 모든 인원을 담고, 앞에서 빼고 뒤로 넣어서 순환시키며 계산했습니다.
그러나 이런 식으로 순환하니까 풀리긴 하나 메모리 공간을 많이 차지하는 이슈가 발생해서, 다른 솔루션을 찾아 본 결과 요세푸스 문제의 점화식으로 푸는 방법이 있음을 확인하였습니다. 추후 관련한 설명이 있으면 좋을 듯?

---

## Programmers

### 72414. 광고 삽입

> Runtime: 7.60ms
> Memory: 79.9MB

#### 🚩 문제 난이도

- [ ] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [X] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

시간을 어떻게 사용해야 할 지에 대한 감을 못 잡다가 힌트 보고 풀었어요. 시간 변환에 대한 키포인트만 캐치하면 문제 자체는 평이한 듯.

