### PR TITLE
[정필모] 2024-07-09 풀이 제출

### DIFF
--- a/week6/leetcode/1701-average-waiting-time/itsmo1031.java
+++ b/week6/leetcode/1701-average-waiting-time/itsmo1031.java
@@ -1,0 +1,18 @@
+class Solution {
+	public double averageWaitingTime(int[][] customers) {
+		double currentTime = 0;
+		double totalWaitingTime = 0;
+
+		for (int[] c : customers) {
+			if (currentTime < c[0]) {
+				currentTime = c[0] + c[1];
+				totalWaitingTime += c[1];
+				continue;
+			}
+			currentTime += c[1];
+			totalWaitingTime += currentTime - c[0];
+		}
+
+		return totalWaitingTime / customers.length;
+	}
+}

--- a/week6/programmers/76502-괄호-회전하기/itsmo1031.java
+++ b/week6/programmers/76502-괄호-회전하기/itsmo1031.java
@@ -1,0 +1,63 @@
+import java.util.*;
+
+class Solution {
+	static char[] arr;
+
+	public int solution(String s) {
+		int len = s.length();
+		s += s;
+		arr = s.toCharArray();
+		int answer = 0;
+
+		for (int i = 0; i < len; i++) {
+			if (check(i, len)) {
+				i += 1;
+				answer += 1;
+			}
+		}
+
+		return answer;
+	}
+
+	static boolean check(int idx, int length) {
+		Deque<Character> q = new ArrayDeque<>();
+
+		for (int i = idx; i < idx + length; i++) {
+			if (q.isEmpty()) {
+				if (isClose(arr[i])) {
+					return false;
+				}
+				q.offerLast(arr[i]);
+				continue;
+			}
+			if (isSame(q.peekLast(), arr[i])) {
+				q.pollLast();
+				continue;
+			}
+			if (isClose(arr[i])) {
+				return false;
+			}
+			q.offerLast(arr[i]);
+		}
+
+		if (!q.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	static boolean isClose(char c) {
+		return c == '}' || c == ')' || c == ']';
+	}
+
+	static boolean isSame(char a, char b) {
+		if (a == '[' && b == ']')
+			return true;
+		if (a == '{' && b == '}')
+			return true;
+		if (a == '(' && b == ')')
+			return true;
+		return false;
+	}
+}


### PR DESCRIPTION
# 2024-07-09

## Leetcode

### 1701. Average Waiting Time

> Runtime: 3ms
> Memory: 72.49MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

고객의 입장 시간이 오름차순으로 들어오므로, 현재 시간을 체크하면서 다음 손님의 입장 시각이 현재 시각보다 큰지 작은지에 따라 로직을 다르게 해서 풀이했습니다.

---

## Programmers

### 76502. 괄호 회전하기

> Runtime: 1.82ms
> Memory: 75.3MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

문자열을 딱 한 바퀴만 회전하면 되니, 문자열을 그대로 두배로 늘려 이를 char 배열로 변환 후 인덱스를 하나씩 늘려 올바른 괄호인지 체크했습니다.
