### PR TITLE
[정필모] 2024-07-11 풀이 제출

### DIFF
--- a/week6/leetcode/1190-reverse-substrings-between-each-pair-of-parentheses/itsmo1031.java
+++ b/week6/leetcode/1190-reverse-substrings-between-each-pair-of-parentheses/itsmo1031.java
@@ -1,0 +1,42 @@
+import java.util.*;
+
+class Solution {
+	static Deque<Character> q;
+
+	public String reverseParentheses(String s) {
+		q = new ArrayDeque<>();
+
+		for (char c : s.toCharArray()) {
+			if (c == ')') {
+				flip();
+			} else {
+				q.offerLast(c);
+			}
+		}
+
+		return print();
+	}
+
+	static void flip() {
+		Deque<Character> temp = new ArrayDeque<>();
+
+		char next;
+		while ((next = q.pollLast()) != '(') {
+			temp.offerLast(next);
+		}
+
+		while (!temp.isEmpty()) {
+			q.offerLast(temp.pollFirst());
+		}
+	}
+
+	static String print() {
+		StringBuilder sb = new StringBuilder();
+
+		for (char c : q) {
+			sb.append(c);
+		}
+
+		return sb.toString();
+	}
+}

--- a/week6/programmers/64065-튜플/itsmo1031.java
+++ b/week6/programmers/64065-튜플/itsmo1031.java
@@ -1,0 +1,29 @@
+import java.util.*;
+
+class Solution {
+	public int[] solution(String s) {
+		String[] arr = s.split("\\},\\{");
+		arr[0] = arr[0].replace("{{", "");
+		arr[arr.length - 1] = arr[arr.length - 1].replace("}}", "");
+
+		Arrays.sort(arr, (s1, s2) -> s1.length() - s2.length());
+
+		List<Integer> list = new ArrayList<>();
+
+		for (String str : arr) {
+			String[] splitted = str.split(",");
+			for (String elem : splitted) {
+				int e = Integer.parseInt(elem);
+				if (!list.contains(e)) {
+					list.add(e);
+				}
+			}
+		}
+
+		int[] answer = list.stream()
+				.mapToInt(Integer::intValue)
+				.toArray();
+
+		return answer;
+	}
+}


### PR DESCRIPTION
# 2024-07-11

## Leetcode

### 1190. Reverse Substrings Between Each Pair of Parentheses

> Runtime: 2ms
> Memory: 41.97MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

Stack(Deque)를 이용해서 닫는 괄호를 만나면 뒤집는 방식으로 나이브하게 풀었는데, 문자열이 커질 경우 시간 복잡도가 $O(n^2)$이 나오더라고요... Editorial의 2번 method가 아이디어가 좋아서 해당 테크닉도 공부해 두면 좋을 것 같습니다.

---

## Programmers

### 64065. 튜플

> Runtime: 2.69ms
> Memory: 77MB

#### 🚩 문제 난이도

- [ ] ✅ 막힘 없이 풀었어요.
- [X] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

처음엔 문자열을 나누고 길이 순으로 정렬한 후, 요소 하나씩 순회하면서 없는 애들만 추가하면서 최종본을 만들었는데, ArrayList의 contains를 사용한데다가 List를 다시 int배열로 변환하는 과정이 있어 최악의 경우에는 시간 초과가 날 수도 있겠다는 생각을 했습니다. 풀이 이후 Set과 고정된 int배열을 사용해서 다시 풀이했는데 런타임은 0.8ms까지 줄어든 반면 메모리가 80MB까지 늘어버려서 그냥 원 풀이로 제출합니다.