### PR TITLE
[정필모] 240719 풀이 제출

### DIFF
--- a/week7/leetcode/1380-lucky-numbers-in-a-matrix/itsmo1031.java
+++ b/week7/leetcode/1380-lucky-numbers-in-a-matrix/itsmo1031.java
@@ -1,0 +1,28 @@
+import java.util.*;
+
+class Solution {
+	public List<Integer> luckyNumbers(int[][] matrix) {
+		List<Integer> row = new ArrayList<>();
+		List<Integer> col = new ArrayList<>();
+
+		for (int r = 0; r < matrix.length; r++) {
+			int min = Integer.MAX_VALUE;
+			for (int c = 0; c < matrix[0].length; c++) {
+				min = Math.min(min, matrix[r][c]);
+			}
+			row.add(min);
+		}
+
+		for (int c = 0; c < matrix[0].length; c++) {
+			int max = Integer.MIN_VALUE;
+			for (int r = 0; r < matrix.length; r++) {
+				max = Math.max(max, matrix[r][c]);
+			}
+			col.add(max);
+		}
+
+		row.retainAll(col);
+
+		return row;
+	}
+}

--- a/week7/programmers/17684-압축/itsmo1031.java
+++ b/week7/programmers/17684-압축/itsmo1031.java
@@ -1,0 +1,41 @@
+import java.util.*;
+
+class Solution {
+	static Map<String, Integer> dict;
+	static int dictIdx;
+
+	public int[] solution(String msg) {
+		return compress(msg);
+	}
+
+	static void init() {
+		dictIdx = 1;
+		dict = new HashMap<>();
+
+		for (char c = 'A'; c <= 'Z'; c++) {
+			dict.put(Character.toString(c), dictIdx++);
+		}
+	}
+
+	static int[] compress(String msg) {
+		init();
+
+		List<Integer> compressed = new ArrayList<>();
+
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < msg.length(); i++) {
+			sb.append(msg.charAt(i));
+			if (!dict.containsKey(sb.toString())) {
+				dict.put(sb.toString(), dictIdx++);
+				compressed.add(dict.get(sb.substring(0, sb.length() - 1)));
+				sb.delete(0, sb.length() - 1);
+			}
+		}
+
+		compressed.add(dict.get(sb.toString()));
+
+		return compressed.stream()
+				.mapToInt(Integer::intValue)
+				.toArray();
+	}
+}


### PR DESCRIPTION
# 2024-07-19

## Leetcode

### 1380. Lucky Numbers in a Matrix

> Runtime: 4ms
> Memory: 45MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

각 행의 최솟값과을 담은 리스트와 각 열의 최댓값을 담은 리스트를 따로 만들고, 두 리스트의 교집합(retainAll)을 구해 풀이했습니다.

---

## Programmers

### 17684. 압축

> Runtime: 4.11ms
> Memory: 78.9MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

문자열을 키로 가지고 인덱스를 값으로 가지는 HashMap을 만든 후, StringBuilder를 사용해 문자열을 처음부터 쭉 담다가 처음 보는 문자열을 발견했을 경우 바로 이전 문자열까지의 색인을 리스트에 담고, 현 문자열에 대한 새로운 색인을 만드는 방식으로 풀이했습니다.
