### PR TITLE
[정필모] 20240726 풀이 제출

### DIFF
--- a/week8/leetcode/1334-find-the-city-with-the-smallest-number-of-neighbors-at-a-threshold-distance/itsmo1031.java
+++ b/week8/leetcode/1334-find-the-city-with-the-smallest-number-of-neighbors-at-a-threshold-distance/itsmo1031.java
@@ -1,0 +1,49 @@
+import java.util.*;
+
+class Solution {
+	static private final int INF = (int) 1e9;
+
+	public int findTheCity(int n, int[][] edges, int distanceThreshold) {
+		int[][] dist = new int[n][n];
+
+		for (int r = 0; r < n; r++) {
+			Arrays.fill(dist[r], INF);
+			dist[r][r] = 0;
+		}
+
+		for (int[] edge : edges) {
+			int from = edge[0];
+			int to = edge[1];
+			int weight = edge[2];
+
+			dist[from][to] = weight;
+			dist[to][from] = weight;
+		}
+
+		for (int k = 0; k < n; k++) {
+			for (int i = 0; i < n; i++) {
+				for (int j = 0; j < n; j++) {
+					dist[i][j] = Math.min(dist[i][j], dist[i][k] + dist[k][j]);
+				}
+			}
+		}
+
+		int answer = -1;
+		int min = INF;
+
+		for (int r = 0; r < n; r++) {
+			int cnt = 0;
+			for (int c = 0; c < n; c++) {
+				if (dist[r][c] <= distanceThreshold) {
+					cnt += 1;
+				}
+			}
+			if (cnt <= min) {
+				answer = r;
+				min = cnt;
+			}
+		}
+
+		return answer;
+	}
+}

--- a/week8/programmers/77885-2개-이하로-다른-비트/itsmo1031.java
+++ b/week8/programmers/77885-2개-이하로-다른-비트/itsmo1031.java
@@ -1,0 +1,23 @@
+class Solution {
+	public long[] solution(long[] numbers) {
+		long[] answer = new long[numbers.length];
+
+		for (int i = 0; i < numbers.length; i++) {
+			if (numbers[i] % 2 == 0) {
+				answer[i] = numbers[i] + 1;
+				continue;
+			}
+
+			for (long flag = 1;; flag <<= 1) {
+				if ((numbers[i] & flag) == 0) {
+					long target = numbers[i] | flag;
+					target ^= flag >> 1;
+					answer[i] = target;
+					break;
+				}
+			}
+		}
+
+		return answer;
+	}
+}


### PR DESCRIPTION
# 2024-07-26

## Leetcode

### 1334. Find the City With the Smallest Number of Neighbors at a Threshold Distance

> Runtime: 8ms
> Memory: 44.52MB

#### 🚩 문제 난이도

- [ ] ✅ 막힘 없이 풀었어요.
- [X] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

n이 100까지라 플로이드 워셜을 사용해서 풀이했습니다. 공간 복잡도가 많이 낮게 나오는데 다익스트라를 사용하면 개선할 수 있지 않을까 싶네요. 다익스트라와 플로이드 워셜을 잊고 살았었는데 하루빨리 최단거리 알고리즘에 대해 다시 공부해야겠어요.

---

## Programmers

### 77885. 2개 이하로 다른 비트

> Runtime: 11.52ms
> Memory: 118MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

짝수의 경우 1만 더해주면 되었고, 문제는 홀수 부분이었는데 오른쪽부터 시작해서 가장 먼저 나오는 0과 바로 뒤 1을 교체해주는 식으로 시간을 줄일 수 있었습니다. 비트 연산자를 이렇게 다채롭게 쓴건 처음인 것 같네요.

