### PR TITLE
[정필모] 20240729 풀이 제출

### DIFF
--- a/week9/leetcode/1395-count-number-of-teams/itsmo1031.java
+++ b/week9/leetcode/1395-count-number-of-teams/itsmo1031.java
@@ -1,0 +1,19 @@
+class Solution {
+	public int numTeams(int[] rating) {
+		int answer = 0;
+
+		for (int i = 0; i < rating.length - 2; i++) {
+			for (int j = i + 1; j < rating.length - 1; j++) {
+				for (int k = j + 1; k < rating.length; k++) {
+					if (rating[i] < rating[j] && rating[j] < rating[k]) {
+						answer += 1;
+					} else if (rating[i] > rating[j] && rating[j] > rating[k]) {
+						answer += 1;
+					}
+				}
+			}
+		}
+
+		return answer;
+	}
+}

--- a/week9/programmers/68936-쿼드압축-후-개수-세기/itsmo1031.java
+++ b/week9/programmers/68936-쿼드압축-후-개수-세기/itsmo1031.java
@@ -1,0 +1,33 @@
+class Solution {
+	static int[] answer;
+	static int[][] data;
+
+	public int[] solution(int[][] arr) {
+		answer = new int[2];
+		data = arr;
+
+		compress(0, 0, arr.length, arr.length);
+
+		return answer;
+	}
+
+	static void compress(int sr, int sc, int er, int ec) {
+		int flag = data[sr][sc];
+
+		for (int r = sr; r < er; r++) {
+			for (int c = sc; c < ec; c++) {
+				if (flag != data[r][c]) {
+					int hr = (sr + er) / 2;
+					int hc = (sc + ec) / 2;
+					compress(sr, sc, hr, hc);
+					compress(sr, hc, hr, ec);
+					compress(hr, sc, er, hc);
+					compress(hr, hc, er, ec);
+					return;
+				}
+			}
+		}
+
+		answer[flag] += 1;
+	}
+}


### PR DESCRIPTION
# 2024-07-29

## Leetcode

### 1395. Count Number of Teams

> Runtime: 2800ms
> Memory: 42.05MB

#### 🚩 문제 난이도

- [ ] ✅ 막힘 없이 풀었어요.
- [X] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

문제를 잘못 읽어서 처음에 LIS로 풀었다가 피봤네요... 뚜렷한 알고리즘이 생각이 안나서 브루트포스로 모든 값을 계산했습니다. 덕분에 런타임이 2.8초나 걸렸는데 DP나 트리를 이용해서 푸는 방법을 알아봐야겠어요.

---

## Programmers

### 68936. 쿼드압축 후 개수 세기

> Runtime: 13.07ms
> Memory: 131MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

값이 다를 때 4분할 재귀를 이용해서 풀었습니다.

