### PR TITLE
[김세민] 240802 풀이 제출

### DIFF
--- a/week9/leetcode/2134-minimum-swaps-to-group-all-1s-together-ii/kimgiraffe.java
+++ b/week9/leetcode/2134-minimum-swaps-to-group-all-1s-together-ii/kimgiraffe.java
@@ -1,0 +1,29 @@
+/**
+ * 1읅 가장 많이 포함하는 최소 window 크기 구하기
+ */
+class Solution {
+	public int minSwaps(int[] nums) {
+		int len = nums.length;
+		int sum = 0; // 1의 합
+
+		for (int i = 0; i < len; i++) {
+			sum += nums[i];
+		}
+
+		int count = 0;
+
+		// sliding window 초기화
+		for (int i = 0; i < sum; i++) {
+			count += nums[i];
+		}
+
+		int max = count;
+
+		for (int i = sum; i < len + sum; i++) {
+			count += nums[i % len] - nums[(i - sum + len) % len];
+			max = Math.max(max, count); // 최댓값 개신
+		}
+
+		return sum - max;
+	}
+}

--- a/week9/programmers/118667-두-큐-합-같게-만들기/kimgiraffe.java
+++ b/week9/programmers/118667-두-큐-합-같게-만들기/kimgiraffe.java
@@ -1,0 +1,44 @@
+import java.util.*;
+
+class Solution {
+	public int solution(int[] queue1, int[] queue2) {
+		int answer = 0;
+		long totalSum = 0;
+		long q1Sum = 0;
+
+		Queue<Integer> q1 = new ArrayDeque<>();
+		Queue<Integer> q2 = new ArrayDeque<>();
+
+		for (int idx = 0; idx < queue1.length; idx++) {
+			totalSum += queue1[idx] + queue2[idx];
+			q1Sum += queue1[idx];
+			q1.offer(queue1[idx]);
+			q2.offer(queue2[idx]);
+		}
+
+		if (totalSum % 2 == 1) {
+			return -1;
+		}
+
+		long target = totalSum / 2;
+
+		while (true) {
+			if (answer > (queue1.length + queue2.length) * 2) {
+				return -1;
+			}
+
+			if (q1Sum == target) {
+				break;
+			} else if (q1Sum > target) {
+				q1Sum -= q1.peek();
+				q2.offer(q1.poll());
+			} else {
+				q1Sum += q2.peek();
+				q1.offer(q2.poll());
+			}
+			answer++;
+		}
+
+		return answer;
+	}
+}


### PR DESCRIPTION
# 2024-08-02

## Leetcode

### 2134. Minimum Swaps to Group All 1's Togther II

> Runtime: 4ms
> Memory: 58.8MB

#### 🚩 문제 난이도

- [ ] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [X] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

슬라이딩 윈도우 알고리즘을 이용하는 문제인지는 알았는데, 기준을 잡기 어려워서 좀 헤맸습니다.

---

## Programmers

### 118667. 두 큐 합 같게 만들기

> Runtime:54.86 ms
> Memory: 135MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

두 큐의 모든 원소의 합(`totalSum`)을 구한 후, `queue1`의 합(`q1Sum`)이 `totalSum / 2` 이 될 때까지
`q1Sum`이 `totalSum / 2 `보다 큰 경우, `queue1`에서 원소 하나를 꺼내 `queue2`에 넣고
`q1Sum`이 `totalSum / 2` 보다 작은 경우, `queue2`에서 원소 하나를 꺼내 `queue1`을 넣는 과정을 반복했습니다.
이 때, 반복 횟수가 두 큐의 길이의 합이 2배보다 커지는 경우 무한 반복하여 두 큐의 원소의 합을 같게 만들 수 없는
경우이기 때문에 `-1`을 반환하였습니다. 

