### PR TITLE
[정필모] 20240802 풀이 제출

### DIFF
--- a/week9/leetcode/2134-minimum-swaps-to-group-all-1s-together-ii/itsmo1031.java
+++ b/week9/leetcode/2134-minimum-swaps-to-group-all-1s-together-ii/itsmo1031.java
@@ -1,0 +1,35 @@
+class Solution {
+	public int minSwaps(int[] nums) {
+		int oneCnt = 0;
+
+		for (int num : nums) {
+			if (num == 1) {
+				oneCnt += 1;
+			}
+		}
+
+		int zero = 0;
+
+		for (int i = 0; i < oneCnt; i++) {
+			if (nums[i] == 0) {
+				zero += 1;
+			}
+		}
+
+		int answer = zero;
+
+		for (int i = 1; i < nums.length; i++) {
+			if (nums[i - 1] == 0) {
+				zero--;
+			}
+
+			if (nums[(i + oneCnt - 1) % nums.length] == 0) {
+				zero++;
+			}
+
+			answer = Math.min(zero, answer);
+		}
+
+		return answer;
+	}
+}

--- a/week9/programmers/118667-두-큐-합-같게-만들기/itsmo1031.java
+++ b/week9/programmers/118667-두-큐-합-같게-만들기/itsmo1031.java
@@ -1,0 +1,43 @@
+import java.util.*;
+
+class Solution {
+	public int solution(int[] queue1, int[] queue2) {
+		Queue<Integer> q1 = new ArrayDeque<>();
+		Queue<Integer> q2 = new ArrayDeque<>();
+		long q1Sum = 0;
+		long q2Sum = 0;
+
+		for (int num : queue1) {
+			q1.offer(num);
+			q1Sum += num;
+		}
+
+		for (int num : queue2) {
+			q2.offer(num);
+			q2Sum += num;
+		}
+
+		int size = q1.size() + q2.size();
+
+		int cnt = 0;
+		while (cnt <= size * 2) {
+			if (q1Sum < q2Sum) {
+				int num = q2.poll();
+				q1Sum += num;
+				q2Sum -= num;
+				q1.offer(num);
+				cnt += 1;
+			} else if (q1Sum > q2Sum) {
+				int num = q1.poll();
+				q1Sum -= num;
+				q2Sum += num;
+				q2.offer(num);
+				cnt += 1;
+			} else {
+				break;
+			}
+		}
+
+		return cnt > size * 2 ? -1 : cnt;
+	}
+}


### PR DESCRIPTION
# 2024-08-02

## Leetcode

### 2134. Minimum Swaps to Group All 1's Together II

> Runtime: 8ms
> Memory: 59.61MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

Sliding Window기법을 이용하여, 배열 내 1의 개수를 구한 후 해당 길이만큼 잘라서 0의 개수를 구해 계산했습니다.

---

## Programmers

### 118667. 두 큐 합 같게 만들기

> Runtime: 57.10ms
> Memory: 149MB

#### 🚩 문제 난이도

- [X] ✅ 막힘 없이 풀었어요.
- [ ] 🤔 풀긴 했는데, 코드를 개선할 수 있을 것 같아요.
- [ ] 🔥 30분 이상 고민할 정도로 어려웠어요.
- [ ] 🙋‍♂️ 어려워서 못 풀었어요.

#### 📌 이렇게 풀었어요

Queue 2개를 선언하고 이의 총합을 비교하면서 넣고 빼는 방식으로 비교했습니다. 총 비교 횟수가 전체 사이즈의 2배정도가 될 경우 가능성이 없다고 판단했습니다.

